### PR TITLE
dont crash when room # doesnt exists

### DIFF
--- a/app.js
+++ b/app.js
@@ -123,7 +123,7 @@ io.sockets.on('connection', function (socket) {
 		inRoom = data.roomId;
 		io.sockets.in(inRoom).emit('newVoter', data);
 		models.Room.findOne({ roomId: inRoom }, function(err, room){
-			if(err){ console.error('Couldn\'t find room '+inRoom); return; }
+			if(err || !room){ console.error('Couldn\'t find room '+inRoom); return; }
 			room.addUser(data);
 		});
 	});


### PR DESCRIPTION
BitPoints crash when joining an invalid room id
1. Start BitPoints
2. In Join Room section, enter an invalid room id (room id that doesn't exists)
3. Hit "Join Room" button.
4. Crash
