### PR TITLE
url encode jira title

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ As a user with Administrator privileges, add this code block to the 'Announcemen
 // BitPoints Integration
 jQuery(function(){
   if(jQuery('#key-val').length > 0){
-    jQuery('<img src="http://{{BITPOINTS_HOST}}/addTicketCookie?ticketSystem=jira&ticketHost={{JIRA_HOST}}&ticketID='+jQuery('#key-val').text()+'&ticketTitle='+jQuery('#summary-val').text()+'" style="width:1px;height:1px;position:absolute;" />').appendTo('body');
+    jQuery('<img src="http://{{BITPOINTS_HOST}}/addTicketCookie?ticketSystem=jira&ticketHost={{JIRA_HOST}}&ticketID='+jQuery('#key-val').text()+'&ticketTitle='+encodeURIComponent(jQuery('#summary-val').text())+'" style="width:1px;height:1px;position:absolute;" />').appendTo('body');
   }
 });
 </script>


### PR DESCRIPTION
Need to url encode jira title or else everything after `&` is gone.

Steps to reproduce
1. Create a room
2. in a new browser tab, open `https://jira.freewebs.com/browse/FWB-37354`
3. Go back to BitPoints
4. The title is `Webs Spring` instead of `Webs Spring & Property Normalization`
