### PR TITLE
Announce the room on the invite screen

### DIFF
--- a/app.js
+++ b/app.js
@@ -75,7 +75,7 @@ app.use(express.urlencoded());
 app.use(express.methodOverride());
 app.use(express.cookieParser());
 app.use(app.router);
-app.use(require('less-middleware')({ src: path.join(__dirname, 'public') }));
+app.use(require('less-middleware')(path.join(__dirname, 'public')));
 app.use(express.static(path.join(__dirname, 'public')));
 mongoose.connect('mongodb://'+config.mongoHost+'/BitPoints');
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "author": "Michael Barrett @twisterghost",
   "contributors":[
     "Nick Swider @swider",
-    "Jack Anderson @jackwanders"
+    "Jack Anderson @jackwanders",
+    "@rektide"
   ],
   "scripts": {
     "start": "node app.js"
@@ -18,7 +19,7 @@
   "dependencies": {
     "express": "3.4.8",
     "jade": "*",
-    "less-middleware": "*",
+    "less-middleware": "^0.2",
     "socket.io": "~0.9.16",
     "gravatar": "*",
     "mongoose": "3.8.x",

--- a/public/javascripts/host.js
+++ b/public/javascripts/host.js
@@ -231,10 +231,10 @@ var page = new BP.Page({
 		if (!window.welcomed && window.SpeechSynthesisUtterance) {
 			var chars = link.substring(link.lastIndexOf("/")+1),
 				letters = chars.split('').join(' '),
-				text = 'Today\'s BitPoints is brought to you by the letters '+letters,
+				text = 'Today\'s BitPoints are brought to you by the letters '+letters,
 				speach= new window.SpeechSynthesisUtterance();
 			speach.text = text;
-			window.speachSynthesis.speak(speach);
+			window.speechSynthesis.speak(speach);
 			window.welcomed = true;
 		}
 

--- a/public/javascripts/host.js
+++ b/public/javascripts/host.js
@@ -228,14 +228,14 @@ var page = new BP.Page({
 				content: link,
 				size: 'large'
 			});
-		if (!window.welcomed && window.SpeechSynthesisUtterance) {
+		if (!BP.welcomed && window.SpeechSynthesisUtterance) {
 			var chars = link.substring(link.lastIndexOf("/")+1),
 				letters = chars.split('').join(' '),
 				text = 'Today\'s BitPoints are brought to you by the letters '+letters,
 				speach= new window.SpeechSynthesisUtterance();
 			speach.text = text;
 			window.speechSynthesis.speak(speach);
-			window.welcomed = true;
+			BP.welcomed = true;
 		}
 
 		modal.show();

--- a/public/javascripts/host.js
+++ b/public/javascripts/host.js
@@ -228,6 +228,15 @@ var page = new BP.Page({
 				content: link,
 				size: 'large'
 			});
+		if (!window.welcomed && window.SpeechSynthesisUtterance) {
+			var chars = link.substring(link.lastIndexOf("/")+1),
+				letters = chars.split('').join(' '),
+				text = 'Today\'s BitPoints is brought to you by the letters '+letters,
+				speach= new window.SpeechSynthesisUtterance();
+			speach.text = text;
+			window.speachSynthesis.speak(speach);
+			window.welcomed = true;
+		}
 
 		modal.show();
 	},


### PR DESCRIPTION
The first time the host brings up the Invite modal, announce the room.
Also, less-middleware fix for 0.2.x. Will break older less-middlewares.