### PR TITLE
Round to nearest card

### DIFF
--- a/public/javascripts/host.js
+++ b/public/javascripts/host.js
@@ -87,6 +87,31 @@ var getDeck = function() {
 	return decks[$('input[name=deckType]:checked').val() || 'standard'];
 };
 
+var useNearestRounding = function() {
+	return $('input[name=roundNearest]:checked').val();
+};
+
+var getNearestCard = function(average, deck) {
+  var compareArr = [];
+  BP.each(deck, function(card) {
+    if(!isNaN(card.value)) {
+      compareArr.push(card);
+    }
+  });
+
+  var curr = compareArr[0];
+  var diff = Math.abs (average - curr.value);
+  BP.each(compareArr, function(compareVal) {
+    var newdiff = Math.abs (average - compareVal.value);
+    if (newdiff < diff) {
+      diff = newdiff;
+      curr = compareVal;
+    }
+  });
+
+  return curr;
+};
+
 var getNumVotes = function() {
 	var count = 0;
 	BP.each(votes,function() {
@@ -109,6 +134,7 @@ var processVotes = function() {
 	};
 
 	var deck = getDeck();
+	var nearestRounding = useNearestRounding();
 	var minCardIdx = 0, maxCardIdx = 0;
 
 	BP.each(votes, function(vote) {
@@ -132,11 +158,17 @@ var processVotes = function() {
 	});
 
 	voteData.spread = maxCardIdx - minCardIdx;
-	voteData.average = voteData.numVotes === 0 ? 0 : voteData.total/voteData.numVotes;
-	if(voteData.average > 0.5) {
-		voteData.trueAverage = voteData.average;
-		voteData.average = Math.round(voteData.average);
+
+	voteData.average = voteData.numVotes === 0 ? 0 : voteData.total / voteData.numVotes;
+
+	if (nearestRounding) {
+    voteData.nearestCard = getNearestCard(voteData.average, deck);
 	}
+
+  if (voteData.average > 0.5) {
+    voteData.trueAverage = voteData.average;
+    voteData.average = Math.round(voteData.average);
+  }
 };
 
 var page = new BP.Page({
@@ -165,6 +197,7 @@ var page = new BP.Page({
 		users: '#users',
 		ticket: '#ticket',
 		average: '#average',
+    nearestCard: '#nearestCard',
 		largeSpread: '#largeSpread'
 	},
 
@@ -269,6 +302,7 @@ var page = new BP.Page({
 	startNewRound: function(e, $el) {
 		voting = true;
 		this.$average.hide().find('.val').empty();
+		this.$nearestCard.hide().find('.val').empty();
 		this.$largeSpread.hide();
 		$el.text('Stop Estimating');
 		this.$('.card').removeClass('visible showValue spin');
@@ -318,6 +352,12 @@ var page = new BP.Page({
 				averageText += ' - The vote spread is large';
 			}
 
+			var nearestText = '';
+			if (voteData.nearestCard) {
+        nearestText = voteData.nearestCard.estimate;
+        this.$nearestCard.show().find('.val').text(nearestText);
+			}
+
 			this.$average.show().find('.val').text(outcomeText);
 			this.$average.show().find('.val').attr('title', averageText);
 
@@ -327,7 +367,7 @@ var page = new BP.Page({
 			}
 		}
 
-		socket.emit('roundEnd',{roomId: roomId, outcome: outcomeText});
+		socket.emit('roundEnd',{roomId: roomId, outcome: outcomeText, nearestCard: nearestText});
 	},
 
 	toggleRound: function(e, $el){

--- a/public/javascripts/host.js
+++ b/public/javascripts/host.js
@@ -163,7 +163,7 @@ var processVotes = function() {
 	voteData.average = voteData.numVotes === 0 ? 0 : voteData.total / voteData.numVotes;
 
 	if (nearestRounding) {
-    voteData.nearestCard = getNearestCard(voteData.average, deck);
+	    voteData.nearestCard = getNearestCard(voteData.average, deck);
 	}
 
   if (voteData.average > 0.5) {

--- a/public/javascripts/host.js
+++ b/public/javascripts/host.js
@@ -198,7 +198,7 @@ var page = new BP.Page({
 		users: '#users',
 		ticket: '#ticket',
 		average: '#average',
-    nearestCard: '#nearestCard',
+		nearestCard: '#nearestCard',
 		largeSpread: '#largeSpread'
 	},
 

--- a/public/javascripts/join.js
+++ b/public/javascripts/join.js
@@ -149,6 +149,9 @@ var page = new BP.Page({
 
 		if (data.outcome) {
 			text += ' Outcome: ' + data.outcome;
+			if (data.nearestCard) {
+				text += ' Nearest Card: ' + data.nearestCard;
+			}
 		}
 
 		this.$status.hide().filter('.roundEnd').text(text).show();

--- a/public/stylesheets/hostRoom.less
+++ b/public/stylesheets/hostRoom.less
@@ -83,6 +83,7 @@ body { perspective: 1000; }
 }
 
 #average,
+#nearestCard,
 #largeSpread {
 	display: none;
 	float: left;

--- a/views/host.jade
+++ b/views/host.jade
@@ -28,6 +28,12 @@ block content
 									input(type="radio", value="tshirt", name="deckType", id="tshirt")
 									span T-Shirt Sizes
 					.dropItem
+						span.title Round To Card:
+						.control
+							.option
+								label(for="roundNearest")
+									input(type="checkbox", name="roundNearest" id="roundNearest")
+					.dropItem
 						span.title Invite URL:
 						.control
 							span
@@ -37,6 +43,8 @@ block content
 		button#toggleRound Begin Estimating
 
 		#average The average estimate is&nbsp;
+			span.val
+		#nearestCard The nearest card is&nbsp;
 			span.val
 		#largeSpread Looks like there's some uncertainty about this estimate...
 


### PR DESCRIPTION
## Description
Sometimes it is helpful to provide the nearest card that the average equates to.  This option allows the Host to show what the average point value equates to in the current deck.

### Code Details
* Created toggle in host.js for option value
* Created function `getNearestCard` which returns the card closest to the `voteData.average`
* Created DOM for option
* Created DOM for results to host
* Created DOM for results to joined user
* LESS styling

### Screen Shot
<img width="1093" alt="screen shot 2017-04-06 at 4 08 21 pm" src="https://cloud.githubusercontent.com/assets/5241186/24773555/abb4b5b2-1ae3-11e7-8299-73e232be5972.png">
